### PR TITLE
Update turn system with per-agent order

### DIFF
--- a/Assets/Scripts/AgentController.cs
+++ b/Assets/Scripts/AgentController.cs
@@ -5,6 +5,7 @@ public class AgentController : MonoBehaviour
     public AgentStats stats = new AgentStats();
     public Vector2Int gridPosition;
     public bool hasBall;
+    public int number;
 
     private void Start()
     {
@@ -23,6 +24,10 @@ public class AgentController : MonoBehaviour
 
     public void MoveTo(Vector2Int cell)
     {
+        if (GameManager.Instance.IsCellOccupied(cell))
+            return;
+
+        GameManager.Instance.UpdateAgentCell(this, cell);
         gridPosition = cell;
         transform.position = GridManager.Instance.CellToWorld(cell);
     }

--- a/Assets/Scripts/BallController.cs
+++ b/Assets/Scripts/BallController.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+public class BallController : MonoBehaviour
+{
+    public Vector3 velocity;
+    public AgentController possessor;
+
+    public bool IsPossessed => possessor != null;
+
+    public void MoveBall()
+    {
+        if (IsPossessed)
+        {
+            transform.position = possessor.transform.position;
+        }
+        else
+        {
+            transform.position += velocity;
+        }
+    }
+}

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -3,12 +3,21 @@ using UnityEngine;
 
 public class GameManager : MonoBehaviour
 {
+    public static GameManager Instance { get; private set; }
     public GameObject agentPrefab;
 
     private readonly List<AgentController> teamA = new();
     private readonly List<AgentController> teamB = new();
     private readonly List<AgentController> turnOrder = new();
     private int currentTurn;
+
+    private readonly Dictionary<Vector2Int, AgentController> board = new();
+    public BallController ball;
+
+    private void Awake()
+    {
+        Instance = this;
+    }
 
     private void Start()
     {
@@ -18,6 +27,7 @@ public class GameManager : MonoBehaviour
         }
 
         SpawnTeams();
+        SpawnBall();
         DetermineTurnOrder();
     }
 
@@ -29,15 +39,27 @@ public class GameManager : MonoBehaviour
             var a = Instantiate(agentPrefab);
             var ac = a.GetComponent<AgentController>();
             ac.Initialize(new Vector2Int(centerRow - 1 + i, 3));
+            ac.number = i + 1;
             teamA.Add(ac);
+            board[ac.gridPosition] = ac;
 
             var b = Instantiate(agentPrefab);
             var bc = b.GetComponent<AgentController>();
             bc.Initialize(new Vector2Int(centerRow - 1 + i, GridManager.Instance.columns - 4));
+            bc.number = i + 4;
             teamB.Add(bc);
+            board[bc.gridPosition] = bc;
         }
 
         teamA[0].hasBall = true;
+    }
+
+    private void SpawnBall()
+    {
+        var go = GameObject.CreatePrimitive(PrimitiveType.Sphere);
+        ball = go.AddComponent<BallController>();
+        ball.possessor = teamA[0];
+        ball.transform.position = teamA[0].transform.position;
     }
 
     private void DetermineTurnOrder()
@@ -45,7 +67,13 @@ public class GameManager : MonoBehaviour
         turnOrder.Clear();
         turnOrder.AddRange(teamA);
         turnOrder.AddRange(teamB);
-        turnOrder.Sort((a, b) => (b.stats.awareness + Dice.Roll(20)).CompareTo(a.stats.awareness + Dice.Roll(20)));
+        for (int i = 0; i < turnOrder.Count; i++)
+        {
+            int j = Random.Range(i, turnOrder.Count);
+            var temp = turnOrder[i];
+            turnOrder[i] = turnOrder[j];
+            turnOrder[j] = temp;
+        }
         currentTurn = 0;
     }
 
@@ -58,6 +86,40 @@ public class GameManager : MonoBehaviour
 
     public void EndTurn()
     {
+        if (ball != null)
+        {
+            ball.MoveBall();
+        }
+
         currentTurn++;
+
+        if (currentTurn >= turnOrder.Count)
+        {
+            DetermineTurnOrder();
+        }
+    }
+
+    public bool IsCellOccupied(Vector2Int cell)
+    {
+        return board.ContainsKey(cell);
+    }
+
+    public void UpdateAgentCell(AgentController agent, Vector2Int newCell)
+    {
+        board.Remove(agent.gridPosition);
+        board[newCell] = agent;
+    }
+
+    private void OnGUI()
+    {
+        GUILayout.BeginHorizontal();
+        foreach (var agent in turnOrder)
+        {
+            string label = agent.number.ToString();
+            if (agent == GetCurrentAgent())
+                label = $">{label}<";
+            GUILayout.Label(label, GUILayout.Width(30));
+        }
+        GUILayout.EndHorizontal();
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Turn Based Football (TBF)
 
-This project contains a minimal prototype of a turn based football game built with Unity. The game uses a 15x40 grid and spawns two teams of three agents. Each agent has several attributes such as Passing, Shooting and Awareness. A simple dice system is used for actions.
+This project contains a minimal prototype of a turn based football game built with Unity. The game uses a 15x40 grid and spawns two teams of three agents. Each agent has several attributes such as Passing, Shooting and Awareness. A simple dice system is used for actions. Agents are assigned jersey numbers and turns are taken one agent at a time in a randomly generated order every cycle.
 
 ## How to run
 
@@ -9,3 +9,4 @@ This project contains a minimal prototype of a turn based football game built wi
 3. Press Play to generate the grid and spawn the placeholder agents.
 
 Agents and grid visuals are simple primitives. GameManager automatically loads the agent prefab from `Resources/Prefabs/Agent`.
+At the end of each turn the ball moves using its current velocity if it is not possessed by any agent.


### PR DESCRIPTION
## Summary
- randomize turn order per agent each cycle
- show jersey numbers and turn order in simple on-screen GUI
- spawn a ball object that moves each turn if no agent possesses it
- prevent agents moving onto occupied cells
- document new behavior in README

## Testing
- `dotnet --version` *(fails: command not found)*
- `mcs -version` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68441caf5008832eb34a3a59b3fa50e6