### PR TITLE
Add per-agent turns and movement rules

### DIFF
--- a/Assets/Scripts/ActionMenu.cs
+++ b/Assets/Scripts/ActionMenu.cs
@@ -56,6 +56,10 @@ public class ActionMenu : MonoBehaviour
                 Ball.Instance.PassTo(targetCell);
             }
             Debug.Log($"Passed ball to {targetCell}");
+            if (agent.actionPoints == 0)
+            {
+                GameManager.Instance.EndAgentTurn();
+            }
         }
         else
         {
@@ -70,6 +74,10 @@ public class ActionMenu : MonoBehaviour
         while (agent.actionPoints > 0 && agent.gridPosition != targetCell)
         {
             Vector2Int nextStep = GetNextStep(agent.gridPosition, targetCell);
+            var occupant = GameManager.Instance.GetAgentAtCell(nextStep);
+            if (occupant != null && occupant != agent)
+                break;
+
             if (nextStep == agent.gridPosition) // No progress possible
                 break;
 
@@ -83,6 +91,11 @@ public class ActionMenu : MonoBehaviour
                 break;
             }
             yield return new WaitForSeconds(0.2f); // Adjust speed as needed
+        }
+
+        if (agent.actionPoints == 0)
+        {
+            GameManager.Instance.EndAgentTurn();
         }
     }
 
@@ -121,6 +134,7 @@ public class ActionMenu : MonoBehaviour
             agent.actionPoints = 0;
             passMode = false;
             UpdateText();
+            GameManager.Instance.EndAgentTurn();
         }
     }
 }

--- a/Assets/Scripts/AgentController.cs
+++ b/Assets/Scripts/AgentController.cs
@@ -6,6 +6,7 @@ public class AgentController : MonoBehaviour
     public Vector2Int gridPosition;
     public bool hasBall;
     public int actionPoints;
+    public int jerseyNumber;
     public Color agentColor = Color.white; // Default to white
 
     private void Start()

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -19,7 +19,7 @@ public class PlayerController : MonoBehaviour
             if (Physics.Raycast(ray, out var hit))
             {
                 var agent = hit.collider.GetComponentInParent<AgentController>();
-                if (agent != null && GameManager.Instance.PlayerAgents.Contains(agent))
+                if (agent != null && agent == GameManager.Instance.CurrentAgent)
                 {
                     SelectAgent(agent);
                 }

--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@ This project contains a minimal prototype of a turn based football game built wi
 3. Press Play to generate the grid and spawn the placeholder agents and ball.
 
 Agents and grid visuals are simple primitives. GameManager automatically loads the agent and ball prefabs from `Resources/Prefabs`.
-During the player's turn you can click one of your agents to open a minimal menu
-showing the remaining action points and simple actions.
+At the start of each cycle the turn order of all agents is randomized and displayed at the top of the screen using their jersey numbers. Agents take turns one after another regardless of team. When an agent finishes their actions the ball moves one step with its current velocity if it is not possessed by anyone.
+Click your active agent to open a minimal menu showing the remaining action points and simple actions.


### PR DESCRIPTION
## Summary
- implement jersey numbers for agents
- randomize turn order each cycle and show agent order on UI
- apply ball velocity between turns
- restrict movement into occupied cells
- document the new turn rules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68442e227f64832ebe0551d667f99d09