### PR TITLE
Add goalkeeper AI

### DIFF
--- a/Assets/Scripts/AgentController.cs
+++ b/Assets/Scripts/AgentController.cs
@@ -6,6 +6,7 @@ public class AgentController : MonoBehaviour
     public AgentStats stats = new AgentStats();
     public Vector2Int gridPosition;
     public bool hasBall;
+    public bool isGoalkeeper = false;
     public int actionPoints;
     public int jerseyNumber;
     public Color agentColor = Color.white; // Default to white

--- a/Assets/Scripts/Ball.cs
+++ b/Assets/Scripts/Ball.cs
@@ -161,4 +161,6 @@ public class Ball : MonoBehaviour
     {
         return isTravelling;
     }
+
+    public Vector2 Velocity => velocity;
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -104,6 +104,28 @@ public class GameManager : MonoBehaviour
             allAgents.Add(bc);
         }
 
+        int gkY = (GridManager.Instance.GoalStartY + GridManager.Instance.GoalEndY) / 2;
+
+        var gkaObj = Instantiate(agentPrefab);
+        var gka = gkaObj.GetComponent<AgentController>();
+        gka.agentColor = Color.blue;
+        gka.jerseyNumber = jersey++;
+        gka.isGoalkeeper = true;
+        gka.Initialize(new Vector2Int(0, gkY));
+        gkaObj.AddComponent<GoalkeeperAI>();
+        teamA.Add(gka);
+        allAgents.Add(gka);
+
+        var gkbObj = Instantiate(agentPrefab);
+        var gkb = gkbObj.GetComponent<AgentController>();
+        gkb.agentColor = Color.red;
+        gkb.jerseyNumber = jersey++;
+        gkb.isGoalkeeper = true;
+        gkb.Initialize(new Vector2Int(GridManager.Instance.width - 1, gkY));
+        gkbObj.AddComponent<GoalkeeperAI>();
+        teamB.Add(gkb);
+        allAgents.Add(gkb);
+
         teamA[0].hasBall = true;
     }
 
@@ -123,6 +145,7 @@ public class GameManager : MonoBehaviour
 
         turnOrder.Clear();
         var copy = new List<AgentController>(allAgents);
+        copy.RemoveAll(a => a.isGoalkeeper);
         while (copy.Count > 0)
         {
             int index = Random.Range(0, copy.Count);

--- a/Assets/Scripts/GoalkeeperAI.cs
+++ b/Assets/Scripts/GoalkeeperAI.cs
@@ -1,0 +1,82 @@
+using UnityEngine;
+
+[RequireComponent(typeof(AgentController))]
+public class GoalkeeperAI : MonoBehaviour
+{
+    private AgentController agent;
+    private int side; // -1 for left, 1 for right
+    private int minY;
+    private int maxY;
+    private int keeperX;
+
+    private void Start()
+    {
+        agent = GetComponent<AgentController>();
+        var gm = GridManager.Instance;
+        side = (agent.gridPosition.x < gm.width / 2) ? -1 : 1;
+        keeperX = side == -1 ? 0 : gm.width - 1;
+        minY = Mathf.Max(0, gm.GoalStartY - 1);
+        maxY = Mathf.Min(gm.height - 1, gm.GoalEndY + 1);
+    }
+
+    private void Update()
+    {
+        if (agent.actionPoints <= 0) return;
+
+        Vector2Int target = DetermineTarget();
+        MoveTowards(target);
+    }
+
+    private Vector2Int DetermineTarget()
+    {
+        var gm = GridManager.Instance;
+        Ball ball = Ball.Instance;
+        if (ball == null)
+            return agent.gridPosition;
+
+        int goalX = side == -1 ? -1 : gm.width;
+        int centerY = (gm.GoalStartY + gm.GoalEndY) / 2;
+
+        // Check if ball is possessed
+        var occupant = GameManager.Instance.GetAgentAtCell(ball.gridPosition);
+        if (occupant != null && occupant.hasBall)
+        {
+            Vector2Int pos = occupant.gridPosition;
+            float t = (keeperX - pos.x) / (float)(goalX - pos.x);
+            float py = pos.y + (centerY - pos.y) * t;
+            int y = Mathf.Clamp(Mathf.RoundToInt(py), minY, maxY);
+            return new Vector2Int(keeperX, y);
+        }
+        else if (ball.IsTravelling() && Mathf.Sign(ball.Velocity.x) == -side)
+        {
+            Vector2 posW = ball.transform.position;
+            Vector2 vel = ball.Velocity;
+            float t = (goalX * gm.cellSize - posW.x) / vel.x;
+            float pyWorld = posW.y + vel.y * t;
+            int y = Mathf.Clamp(Mathf.RoundToInt(pyWorld / gm.cellSize), minY, maxY);
+            return new Vector2Int(keeperX, y);
+        }
+
+        return new Vector2Int(keeperX, Mathf.Clamp(centerY, minY, maxY));
+    }
+
+    private void MoveTowards(Vector2Int target)
+    {
+        if (agent.gridPosition == target)
+            return;
+
+        Vector2Int next = agent.gridPosition;
+        if (target.y > agent.gridPosition.y) next.y += 1;
+        else if (target.y < agent.gridPosition.y) next.y -= 1;
+        next.x = keeperX;
+        next.y = Mathf.Clamp(next.y, minY, maxY);
+
+        if (!GameManager.Instance.IsCellOccupied(next))
+        {
+            if (agent.SpendActionPoints(1))
+            {
+                agent.MoveTo(next);
+            }
+        }
+    }
+}

--- a/Assets/Scripts/GridManager.cs
+++ b/Assets/Scripts/GridManager.cs
@@ -12,8 +12,8 @@ public class GridManager : MonoBehaviour
     public GameObject gridCanvas; // Assign this in the Inspector
 
 
-    private int GoalStartY => Mathf.Max(0, (height - goalWidth) / 2);
-    private int GoalEndY => Mathf.Min(height - 1, GoalStartY + goalWidth - 1);
+    public int GoalStartY => Mathf.Max(0, (height - goalWidth) / 2);
+    public int GoalEndY => Mathf.Min(height - 1, GoalStartY + goalWidth - 1);
 
     private void Awake()
     {

--- a/Assets/Scripts/ImmediateActionMenu.cs
+++ b/Assets/Scripts/ImmediateActionMenu.cs
@@ -14,7 +14,7 @@ public class ImmediateActionMenu : MonoBehaviour
     {
         agent = a;
         gameObject.SetActive(true);
-        passMode = false;
+        passMode = agent.isGoalkeeper; // GK goes directly to pass mode
         UpdateText();
     }
 
@@ -41,10 +41,18 @@ public class ImmediateActionMenu : MonoBehaviour
             return;
         }
 
-        menuText.text = "Immediate Action:\n" +
-                        "1) Control Ball\n" +
-                        "2) One-Touch Pass\n" +
-                        "3) Do Nothing";
+        if (agent.isGoalkeeper)
+        {
+            menuText.text = "Click a cell for one-touch pass.";
+            passMode = true;
+        }
+        else
+        {
+            menuText.text = "Immediate Action:\n" +
+                            "1) Control Ball\n" +
+                            "2) One-Touch Pass\n" +
+                            "3) Do Nothing";
+        }
     }
 
     public void PassOrder(Vector2Int cell)
@@ -60,7 +68,7 @@ public class ImmediateActionMenu : MonoBehaviour
     {
         if (!gameObject.activeSelf || agent == null) return;
 
-        if (passMode) return;
+        if (agent.isGoalkeeper || passMode) return;
 
         if (Input.GetKeyDown(KeyCode.Alpha1))
         {


### PR DESCRIPTION
## Summary
- add `isGoalkeeper` attribute to `AgentController`
- expose `Velocity` in `Ball`
- spawn AI controlled goalkeepers for each team
- exclude keepers from player turn order
- implement `GoalkeeperAI` script for simple positioning logic
- adjust immediate action menu to only allow one‑touch pass for keepers
- publish goal size information from `GridManager`

## Testing
- `mcs -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845648f6654832e85c3b59a6cb24a72