### PR TITLE
Add basic AI for red team

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -16,6 +16,11 @@ public class GameManager : MonoBehaviour
     private int currentAgentIndex = 0;
     private Ball ball;
 
+    [Header("AI Settings")]
+    public bool enableRedAI = true;
+    private RedTeamAI aiController;
+    private Coroutine aiRoutine;
+
     private AgentController savedSelection;
     private bool savedMenuVisible;
 
@@ -24,6 +29,7 @@ public class GameManager : MonoBehaviour
     public AgentController CurrentAgent => turnOrder.Count > 0 ? turnOrder[currentAgentIndex] : null;
     public List<AgentController> PlayerAgents => teamA;
     public List<AgentController> AllAgents => allAgents;
+    public List<AgentController> AIAgents => teamB;
 
     public PlayerController playerController;
     public TextMeshProUGUI orderText;
@@ -35,6 +41,9 @@ public class GameManager : MonoBehaviour
     private void Awake()
     {
         Instance = this;
+        aiController = GetComponent<RedTeamAI>();
+        if (aiController == null)
+            aiController = gameObject.AddComponent<RedTeamAI>();
     }
 
     private IEnumerator Start()
@@ -165,10 +174,15 @@ public class GameManager : MonoBehaviour
     {
         if (CurrentAgent == null)
             return;
-
-        // Auto-select the agent that has the turn
-        if (playerController != null)
+        if (enableRedAI && teamB.Contains(CurrentAgent))
         {
+            if (aiRoutine != null)
+                StopCoroutine(aiRoutine);
+            aiRoutine = StartCoroutine(aiController.TakeTurn(CurrentAgent));
+        }
+        else if (playerController != null)
+        {
+            // Auto-select the agent that has the turn for the player
             playerController.SelectAgent(CurrentAgent);
         }
     }

--- a/Assets/Scripts/RedTeamAI.cs
+++ b/Assets/Scripts/RedTeamAI.cs
@@ -1,0 +1,125 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RedTeamAI : MonoBehaviour
+{
+    public IEnumerator TakeTurn(AgentController agent)
+    {
+        // small delay before starting actions
+        yield return new WaitForSeconds(0.3f);
+
+        while (agent.actionPoints > 0)
+        {
+            if (agent.hasBall)
+            {
+                // If close to the opponent goal, shoot (hard pass to goal cell)
+                if (TryShoot(agent))
+                {
+                    Ball.Instance.AdvanceWithVelocity();
+                    yield return new WaitForSeconds(0.3f);
+                    continue;
+                }
+
+                // Try to pass forward to a teammate
+                if (TryPassForward(agent))
+                {
+                    Ball.Instance.AdvanceWithVelocity();
+                    yield return new WaitForSeconds(0.3f);
+                    continue;
+                }
+
+                // Otherwise move towards the opponent goal
+                Vector2Int target = agent.gridPosition + Vector2Int.left;
+                if (!GameManager.Instance.IsCellOccupied(target))
+                {
+                    if (agent.SpendActionPoints(1))
+                    {
+                        agent.MoveTo(target);
+                        Ball.Instance.AdvanceWithVelocity();
+                    }
+                }
+                else
+                {
+                    agent.SpendActionPoints(1); // wait if blocked
+                }
+            }
+            else
+            {
+                // If on the ball's cell, take control
+                if (Ball.Instance != null && Ball.Instance.gridPosition == agent.gridPosition && !Ball.Instance.IsTravelling())
+                {
+                    agent.hasBall = true;
+                }
+                else
+                {
+                    // Move towards the ball
+                    Vector2Int next = StepTowards(agent.gridPosition, Ball.Instance.gridPosition);
+                    if (!GameManager.Instance.IsCellOccupied(next))
+                    {
+                        if (agent.SpendActionPoints(1))
+                        {
+                            agent.MoveTo(next);
+                            Ball.Instance.AdvanceWithVelocity();
+                        }
+                    }
+                    else
+                    {
+                        agent.SpendActionPoints(1); // wait if blocked
+                    }
+                }
+            }
+
+            yield return new WaitForSeconds(0.3f);
+        }
+
+        GameManager.Instance.EndAgentTurn();
+    }
+
+    private Vector2Int StepTowards(Vector2Int from, Vector2Int to)
+    {
+        Vector2Int step = from;
+        if (from.x != to.x)
+            step.x += from.x < to.x ? 1 : -1;
+        else if (from.y != to.y)
+            step.y += from.y < to.y ? 1 : -1;
+        return step;
+    }
+
+    private bool TryShoot(AgentController agent)
+    {
+        if (agent.gridPosition.x <= 1)
+        {
+            Vector2Int target = new Vector2Int(-1, agent.gridPosition.y);
+            if (agent.SpendActionPoints(1))
+            {
+                agent.hasBall = false;
+                Ball.Instance.PassTo(target, true);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private bool TryPassForward(AgentController agent)
+    {
+        AgentController best = null;
+        int bestX = agent.gridPosition.x;
+        foreach (var a in GameManager.Instance.AIAgents)
+        {
+            if (a == agent) continue;
+            if (a.gridPosition.x < bestX)
+            {
+                best = a;
+                bestX = a.gridPosition.x;
+            }
+        }
+        if (best != null && agent.SpendActionPoints(1))
+        {
+            agent.hasBall = false;
+            Ball.Instance.PassTo(best.gridPosition, false);
+            return true;
+        }
+        return false;
+    }
+}

--- a/Assets/Scripts/RedTeamAI.cs.meta
+++ b/Assets/Scripts/RedTeamAI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d51e9cff69e94ac9a5da0b7e6f0b8e64


### PR DESCRIPTION
## Summary
- implement new `RedTeamAI` class with simple decision making
- add AI settings and hooks in `GameManager` to control red team with AI
- expose list of AI agents

## Testing
- `true` (no tests present)


------
https://chatgpt.com/codex/tasks/task_e_68469217d4ec832ea77800ced811fda9