### PR TITLE
Add red AI immediate response and configurable spawns

### DIFF
--- a/Assets/Scripts/ActionMenu.cs
+++ b/Assets/Scripts/ActionMenu.cs
@@ -73,6 +73,7 @@ public class ActionMenu : MonoBehaviour
 
     public void PassOrder(Vector2Int targetCell)
     {
+        if (agent == null) return;
         passMode = false;
         UpdateText();
 

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -16,6 +16,11 @@ public class GameManager : MonoBehaviour
     private int currentAgentIndex = 0;
     private Ball ball;
 
+    [Header("AI Settings")]
+    public bool enableRedAI = true;
+    private RedTeamAI aiController;
+    private Coroutine aiRoutine;
+
     private AgentController savedSelection;
     private bool savedMenuVisible;
 
@@ -24,17 +29,22 @@ public class GameManager : MonoBehaviour
     public AgentController CurrentAgent => turnOrder.Count > 0 ? turnOrder[currentAgentIndex] : null;
     public List<AgentController> PlayerAgents => teamA;
     public List<AgentController> AllAgents => allAgents;
+    public List<AgentController> AIAgents => teamB;
 
     public PlayerController playerController;
     public TextMeshProUGUI orderText;
 
     [Header("Team Spawn Settings")]
-    public int agentGap = 1; // Set this in the Inspector
+    public List<Vector2Int> leftTeamPositions = new();
+    public Vector2Int leftGoalkeeperPosition = Vector2Int.zero;
     private readonly List<AgentController> goalkeepers = new();
 
     private void Awake()
     {
         Instance = this;
+        aiController = GetComponent<RedTeamAI>();
+        if (aiController == null)
+            aiController = gameObject.AddComponent<RedTeamAI>();
     }
 
     private IEnumerator Start()
@@ -48,7 +58,7 @@ public class GameManager : MonoBehaviour
             ballPrefab = Resources.Load<GameObject>("Prefabs/Ball");
         }
 
-        SpawnTeams(agentGap);
+        SpawnTeams();
         SpawnBall();
 
         // Place camera at the geometric center of the pitch using the four corners
@@ -76,23 +86,28 @@ public class GameManager : MonoBehaviour
         UpdateTurnOrderDisplay();
     }
 
-    private void SpawnTeams(int gap)
+    private void SpawnTeams()
     {
-        int numAgents = 3;
-        int centerColumn = GridManager.Instance.height / 2;
-
-        int startOffset = -((numAgents - 1) / 2) * gap;
-
         int jersey = 1;
-        for (int i = 0; i < numAgents; i++)
+        if (leftTeamPositions.Count == 0)
         {
-            int col = centerColumn + startOffset + i * gap;
+            int numAgents = 3;
+            int centerColumn = GridManager.Instance.height / 2;
+            int startOffset = -((numAgents - 1) / 2);
+            for (int i = 0; i < numAgents; i++)
+            {
+                int col = centerColumn + startOffset + i;
+                leftTeamPositions.Add(new Vector2Int(3, col));
+            }
+        }
 
+        foreach (var pos in leftTeamPositions)
+        {
             var a = Instantiate(agentPrefab);
             var ac = a.GetComponent<AgentController>();
             ac.agentColor = Color.blue;
             ac.jerseyNumber = jersey++;
-            ac.Initialize(new Vector2Int(3, col));
+            ac.Initialize(pos);
             teamA.Add(ac);
             allAgents.Add(ac);
 
@@ -100,29 +115,33 @@ public class GameManager : MonoBehaviour
             var bc = b.GetComponent<AgentController>();
             bc.agentColor = Color.red;
             bc.jerseyNumber = jersey++;
-            bc.Initialize(new Vector2Int(GridManager.Instance.width - 4, col));
+            Vector2Int sym = new Vector2Int(GridManager.Instance.width - 1 - pos.x, pos.y);
+            bc.Initialize(sym);
             teamB.Add(bc);
             allAgents.Add(bc);
         }
 
-        int gkY = (GridManager.Instance.GoalStartY + GridManager.Instance.GoalEndY) / 2;
+        Vector2Int gkA = leftGoalkeeperPosition;
+        if (gkA == Vector2Int.zero)
+            gkA = new Vector2Int(0, (GridManager.Instance.GoalStartY + GridManager.Instance.GoalEndY) / 2);
 
         var gkaObj = Instantiate(agentPrefab);
         var gka = gkaObj.GetComponent<AgentController>();
         gka.agentColor = Color.blue;
         gka.jerseyNumber = jersey++;
         gka.isGoalkeeper = true;
-        gka.Initialize(new Vector2Int(0, gkY));
+        gka.Initialize(gkA);
         gkaObj.AddComponent<GoalkeeperAI>();
         teamA.Add(gka);
         allAgents.Add(gka);
 
+        Vector2Int gkB = new Vector2Int(GridManager.Instance.width - 1 - gkA.x, gkA.y);
         var gkbObj = Instantiate(agentPrefab);
         var gkb = gkbObj.GetComponent<AgentController>();
         gkb.agentColor = Color.red;
         gkb.jerseyNumber = jersey++;
         gkb.isGoalkeeper = true;
-        gkb.Initialize(new Vector2Int(GridManager.Instance.width - 1, gkY));
+        gkb.Initialize(gkB);
         gkbObj.AddComponent<GoalkeeperAI>();
         teamB.Add(gkb);
         allAgents.Add(gkb);
@@ -130,7 +149,8 @@ public class GameManager : MonoBehaviour
         goalkeepers.Add(gka);
         goalkeepers.Add(gkb);
 
-        teamA[0].hasBall = true;
+        if (teamA.Count > 0)
+            teamA[0].hasBall = true;
     }
 
     private void SpawnBall()
@@ -165,10 +185,15 @@ public class GameManager : MonoBehaviour
     {
         if (CurrentAgent == null)
             return;
-
-        // Auto-select the agent that has the turn
-        if (playerController != null)
+        if (enableRedAI && teamB.Contains(CurrentAgent))
         {
+            if (aiRoutine != null)
+                StopCoroutine(aiRoutine);
+            aiRoutine = StartCoroutine(aiController.TakeTurn(CurrentAgent));
+        }
+        else if (playerController != null)
+        {
+            // Auto-select the agent that has the turn for the player
             playerController.SelectAgent(CurrentAgent);
         }
     }
@@ -263,6 +288,12 @@ public class GameManager : MonoBehaviour
 
     public void TriggerImmediateAction(AgentController agent)
     {
+        if (enableRedAI && teamB.Contains(agent))
+        {
+            StartCoroutine(aiController.HandleImmediateAction(agent));
+            return;
+        }
+
         savedSelection = playerController.selected;
         savedMenuVisible = playerController.actionMenu.gameObject.activeSelf;
         playerController.actionMenu.Close();

--- a/Assets/Scripts/PlayerController.cs
+++ b/Assets/Scripts/PlayerController.cs
@@ -48,8 +48,12 @@ public class PlayerController : MonoBehaviour
 
     public void ResetSelection()
     {
-        actionMenu.Close();
-        selected.SetSelected(false);
-        selected = null;
+        if (actionMenu != null)
+            actionMenu.Close();
+        if (selected != null)
+        {
+            selected.SetSelected(false);
+            selected = null;
+        }
     }
 }

--- a/Assets/Scripts/RedTeamAI.cs
+++ b/Assets/Scripts/RedTeamAI.cs
@@ -1,0 +1,145 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class RedTeamAI : MonoBehaviour
+{
+    public IEnumerator TakeTurn(AgentController agent)
+    {
+        // small delay before starting actions
+        yield return new WaitForSeconds(0.3f);
+
+        while (agent.actionPoints > 0)
+        {
+            if (agent.hasBall)
+            {
+                // If close to the opponent goal, shoot (hard pass to goal cell)
+                if (TryShoot(agent))
+                {
+                    Ball.Instance.AdvanceWithVelocity();
+                    yield return new WaitForSeconds(0.3f);
+                    continue;
+                }
+
+                // Try to pass forward to a teammate
+                if (TryPassForward(agent))
+                {
+                    Ball.Instance.AdvanceWithVelocity();
+                    yield return new WaitForSeconds(0.3f);
+                    continue;
+                }
+
+                // Otherwise move towards the opponent goal
+                Vector2Int target = agent.gridPosition + Vector2Int.left;
+                if (!GameManager.Instance.IsCellOccupied(target))
+                {
+                    if (agent.SpendActionPoints(1))
+                    {
+                        agent.MoveTo(target);
+                        Ball.Instance.AdvanceWithVelocity();
+                    }
+                }
+                else
+                {
+                    agent.SpendActionPoints(1); // wait if blocked
+                }
+            }
+            else
+            {
+                // If on the ball's cell, take control
+                if (Ball.Instance != null && Ball.Instance.gridPosition == agent.gridPosition && !Ball.Instance.IsTravelling())
+                {
+                    agent.hasBall = true;
+                }
+                else
+                {
+                    // Move towards the ball
+                    Vector2Int next = StepTowards(agent.gridPosition, Ball.Instance.gridPosition);
+                    if (!GameManager.Instance.IsCellOccupied(next))
+                    {
+                        if (agent.SpendActionPoints(1))
+                        {
+                            agent.MoveTo(next);
+                            Ball.Instance.AdvanceWithVelocity();
+                        }
+                    }
+                    else
+                    {
+                        agent.SpendActionPoints(1); // wait if blocked
+                    }
+                }
+            }
+
+            yield return new WaitForSeconds(0.3f);
+        }
+
+        GameManager.Instance.EndAgentTurn();
+    }
+
+    public IEnumerator HandleImmediateAction(AgentController agent)
+    {
+        // small delay to mimic thinking time
+        yield return new WaitForSeconds(0.2f);
+
+        if (TryShoot(agent))
+        {
+            Ball.Instance.AdvanceWithVelocity();
+            yield break;
+        }
+
+        if (TryPassForward(agent))
+        {
+            Ball.Instance.AdvanceWithVelocity();
+            yield break;
+        }
+
+        agent.hasBall = true;
+    }
+
+    private Vector2Int StepTowards(Vector2Int from, Vector2Int to)
+    {
+        Vector2Int step = from;
+        if (from.x != to.x)
+            step.x += from.x < to.x ? 1 : -1;
+        else if (from.y != to.y)
+            step.y += from.y < to.y ? 1 : -1;
+        return step;
+    }
+
+    private bool TryShoot(AgentController agent)
+    {
+        if (agent.gridPosition.x <= 1)
+        {
+            Vector2Int target = new Vector2Int(-1, agent.gridPosition.y);
+            if (agent.SpendActionPoints(1))
+            {
+                agent.hasBall = false;
+                Ball.Instance.PassTo(target, true);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private bool TryPassForward(AgentController agent)
+    {
+        AgentController best = null;
+        int bestX = agent.gridPosition.x;
+        foreach (var a in GameManager.Instance.AIAgents)
+        {
+            if (a == agent) continue;
+            if (a.gridPosition.x < bestX)
+            {
+                best = a;
+                bestX = a.gridPosition.x;
+            }
+        }
+        if (best != null && agent.SpendActionPoints(1))
+        {
+            agent.hasBall = false;
+            Ball.Instance.PassTo(best.gridPosition, false);
+            return true;
+        }
+        return false;
+    }
+}

--- a/Assets/Scripts/RedTeamAI.cs.meta
+++ b/Assets/Scripts/RedTeamAI.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d51e9cff69e94ac9a5da0b7e6f0b8e64


### PR DESCRIPTION
## Summary
- avoid passing with null agent reference
- add AI-controlled immediate actions for red team
- expose spawn lists for left team and mirror them for right team

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68469217d4ec832ea77800ced811fda9